### PR TITLE
rename Globalset to GlobalSet

### DIFF
--- a/src/Directives/GlobalSet.php
+++ b/src/Directives/GlobalSet.php
@@ -4,7 +4,7 @@ namespace Edalzell\Blade\Directives;
 
 use Statamic\Facades\GlobalSet as GlobalSetAPI;
 
-class Globalset
+class GlobalSet
 {
     public function handleKey(string $handle, string $key = null)
     {


### PR DESCRIPTION
When installing via composer, I am seeing a deprecation notice:
```
Deprecation Notice: Class Edalzell\Blade\Directives\Globalset located in ./vendor/edalzell/blade-directives/src/Directives/GlobalSet.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
```
This should remove the notice by having the classname and filename cases match.