### PR TITLE
test: :white_check_mark: Fix expected strings to match

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ I accept contributions via Pull Requests on [Github](https://github.com/edalzell
 
 - **Consider our release cycle** - I try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
 
-- **Create feature branches** - Don't ask me to pull from your master branch.
+- **Create feature branches** - Don't ask me to pull from your main branch.
 
 - **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Blade Directives
+
 [![MIT Licensed](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 
 This package provides custom directives so you can easily access Statamic data in your Blade templates.
 
 ## Requirements
 
-* PHP 7.4+
-* Statamic v3
+- PHP 7.4+
+- Statamic v3
 
 ## Installation
 
@@ -17,7 +18,6 @@ composer require edalzell/blade-directives
 ```
 
 The package will automatically register itself.
-
 
 ## Usage
 
@@ -33,9 +33,9 @@ The package will automatically register itself.
 ### Collection
 
 ```blade
- @collection('pages', ['where' => 'title:My Title,author:Erin', 'limit' => 3, 'orderBy' => 'title:desc'])
-   {{ $entry['title'] }}
- @endcollection
+@collection('pages', ['where' => 'title:My Title,author:Erin', 'limit' => 3, 'orderBy' => 'title:desc'])
+    {{ $entry['title'] }}
+@endcollection
 ```
 
 ### Globals
@@ -57,6 +57,7 @@ The package will automatically register itself.
 ```
 
 You can use the [same parameters](https://statamic.dev/tags/nav#parameters) as the `nav` tag.
+
 ```blade
 @nav('collection::pages', ['from' => '/', 'show_unpublished' => true, 'include_home' => true])
     {{ $item['title'] }}
@@ -66,6 +67,7 @@ You can use the [same parameters](https://statamic.dev/tags/nav#parameters) as t
 ## Testing
 
 Run the tests with:
+
 ```bash
 vendor/bin/phpunit
 ```

--- a/tests/Unit/DirectivesTest.php
+++ b/tests/Unit/DirectivesTest.php
@@ -10,7 +10,7 @@ class DirectivesTest extends TestCase
     public function does_display_collection_correctly()
     {
         $blade = "@collection('foo')";
-        $expected = "<?php foreach (Facades\Edalzell\Blade\Directives\Collection::handle('foo') as \$entry) { ?>";
+        $expected = "<?php foreach(Facades\Edalzell\Blade\Directives\Collection::handle('foo') as \$entry) { ?>";
 
         $this->assertSame($expected, $this->blade->compileString($blade));
     }
@@ -19,7 +19,7 @@ class DirectivesTest extends TestCase
     public function does_display_bard_correctly()
     {
         $blade = "@bard([])";
-        $expected = "<?php foreach (Facades\Edalzell\Blade\Directives\Bard::handle([]) as \$sets) { ?>";
+        $expected = "<?php foreach(Facades\Edalzell\Blade\Directives\Bard::handle([]) as \$set) { ?>";
 
         $this->assertSame($expected, $this->blade->compileString($blade));
     }


### PR DESCRIPTION
The expected strings didn't match the compiled ones for the existing tests. So this PR fixes this.