### PR TITLE
Correct small syntax typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can use the [same parameters](https://statamic.dev/tags/nav#parameters) as t
 
 ```blade
 @site
-    {{ short_locale }}
+    {{ $short_locale }}
 @endsite
 ```
 


### PR DESCRIPTION
Just noticed a small syntax typo in the readme. Great package btw.