### PR TITLE
getAugmentedValue() does not check for object

### DIFF
--- a/src/Concerns/IsDirective.php
+++ b/src/Concerns/IsDirective.php
@@ -88,7 +88,7 @@ trait IsDirective
             return $data->value();
         }
 
-        if (method_exists($data, 'toAugmentedArray')) {
+        if (is_object($data) && method_exists($data, 'toAugmentedArray')) {
             return $this->getAugmentedValue($data->toAugmentedArray());
         }
 


### PR DESCRIPTION
Calling on @globalset('my-set')...@endglobalset results in a fatal error if in certain cases the data is a boolean or numeric.
Adding a is_object check prevents that.