### PR TITLE
only call on value method on Statamic\Fields\Value instance

### DIFF
--- a/src/Directives/Data.php
+++ b/src/Directives/Data.php
@@ -3,6 +3,7 @@
 namespace Edalzell\Blade\Directives;
 
 use Edalzell\Blade\Concerns\IsDirective;
+use Statamic\Fields\Value;
 use Statamic\Stache\Query\Builder;
 
 class Data
@@ -20,6 +21,10 @@ class Data
             return $this->getAugmentedValue($data->get());
         }
 
-        return $this->getAugmentedValue($data->value());
+        if ($data instanceof Value) {
+            return $this->getAugmentedValue($data->value());
+        }
+
+        return $this->getAugmentedValue($data);
     }
 }


### PR DESCRIPTION
I have a Replicator field which renders different components based on the selected set.

```blade.php
@if($flexible_content)
    @data($flexible_content)
    @foreach($data as $element)
        <x-dynamic-component :component="'flexible.elements.' . $element['type']" :element="$element" />
    @endforeach
    @enddata
@endif
```

One of those dynamic components is `flexible/elements/hero.blade.php`, which is a wrapper that calls my real component `elements/hero.blade.php`

`flexible/elements/hero.blade.php`
```blade.php
@props(['element'])

<x-elements.hero :background="$element['background'] ?? null">
    <x-slot name="banner">{!! $element['overlay'] ?? '' !!}</x-slot>
</x-elements.hero>
```

`elements/hero.blade.php`
```blade.php
@props(['background'])

<div {{ $attributes->merge(['class' => 'flex overflow-hidden']) }}>
    @if($background instanceof \Statamic\Fields\Value)
        @data($background)
        <x-elements.asset :asset="$data"></x-elements.asset>
        @enddata
    @elseif(is_array($background))
        <x-elements.asset :asset="$background"></x-elements.asset>
    @endif


    @if($banner)
        <div class="absolute right-0 bottom-0 left-0 text-white bg-black bg-opacity-75 py-10">
            <x-util.container>
                {{ $banner }}
            </x-util.container>
        </div>
    @endif
</div>
```

I use this `elements/hero.blade.php` component also outside of this dynamic structure.
When I'm inside the dynamic structure the `$background` is already an array as it was resolved when calling `@data($flexible_content)`. When I call it from outside it's an instance of `\Statamic\Fields\Value` and I need to call `@data($background)`.

So I need this `@if($background instanceof \Statamic\Fields\Value)` check to prevent a 500 error when I'm inside the dynamic structure:
`Call to a member function value() on array (View: [...]/resources/views/components/elements/hero.blade.php)`

I found out with the change in this PR I can just do
```blade.php
@if($background)
    @data($background)
    <x-elements.asset :asset="$data"></x-elements.asset>
    @enddata
@endif
```

instead of

```blade.php
@if($background instanceof \Statamic\Fields\Value)
    @data($background)
    <x-elements.asset :asset="$data"></x-elements.asset>
    @enddata
@elseif(is_array($background))
    <x-elements.asset :asset="$background"></x-elements.asset>
@endif
```

but I'm not 100% sure this is safe to do. What do you think?

P.S. If my explanation is to complex please feel free to ask. Maybe next weekend I can come up with an example Repo but currently I have no time to do it.