### PR TITLE
reextract previous data after loop

### DIFF
--- a/src/Concerns/IsDirective.php
+++ b/src/Concerns/IsDirective.php
@@ -113,6 +113,7 @@ trait IsDirective
                         unset($key);
                     }
                     unset($'.$variable.');
+                    extract($__data ?? []);
                 ?>';
     }
 


### PR DESCRIPTION
```blade.php
{{ $title ?? '' }}

@data($child)
{{ $title ?? '' }}
@enddata

// this still prints the title of the child data
{{ $title ?? '' }}

@php
    // as far as I understood Statamic places it's current data in $__data, so we can reextract it here
    extract($__data)
@endphp

{{ $title ?? '' }}
```

results in

```
Parent Title
Child Title
Child Title
Parent Title
```

This PR makes sure that the previous data is available after `@enddata` again.

> Note: I think this shouldn't break the experience of other users, but I'm not sure about it.