### PR TITLE
Allow for passing parameters to Taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,10 @@ You can use the [same parameters](https://statamic.dev/tags/nav#parameters) as t
 
 ## Taxonomy
 
+Use the same params as the `{{ taxonomy }}` tag
+
 ```blade
-@taxonomy('tags')
+@taxonomy('tags', ['limit' => 6, 'sort' => 'entries_count:desc'])
     <p>Title is {{ $term['title'] }}</p>
 @endtaxonomy
 ```

--- a/src/Directives/Taxonomy.php
+++ b/src/Directives/Taxonomy.php
@@ -3,7 +3,6 @@
 namespace Edalzell\Blade\Directives;
 
 use Edalzell\Blade\Concerns\IsDirective;
-use Statamic\Facades\Term;
 
 class Taxonomy
 {
@@ -14,8 +13,13 @@ class Taxonomy
     protected string $type = 'loop';
     protected string $method = 'handle';
 
-    public function handle(string $handle)
+    public function handle(string $handle, array $params = [])
     {
-        return $this->getAugmentedValue(Term::whereTaxonomy($handle));
+        $terms = tag(
+            'taxonomy',
+            array_merge(['from' => $handle], $params)
+        );
+
+        return $this->getAugmentedValue($terms);
     }
 }


### PR DESCRIPTION
This allows for passing arguments to `@taxonomy`, much like collections, ie:

```blade
@taxonomy('tags', ['limit' => 6, 'sort' => 'entries_count:desc'])
    <p>Title is {{ $term['title'] }}</p>
@endtaxonomy
```