### PR TITLE
Make sure we do not get null as response

### DIFF
--- a/src/Directives/GlobalSet.php
+++ b/src/Directives/GlobalSet.php
@@ -16,7 +16,13 @@ class GlobalSet
 
     public function handleKey(string $handle, string $key = null)
     {
-        return $this->globalSet($handle)->get($key);
+        $globalSet = $this->globalSet($handle);
+
+        if (is_null($globalSet)) {
+            return null;
+        }
+
+        return $globalSet->get($key);
     }
 
     public function handle(string $handle)
@@ -26,6 +32,12 @@ class GlobalSet
 
     private function globalSet(string $handle)
     {
-        return GlobalSetAPI::findByHandle($handle)->inCurrentSite();
+        $handle = GlobalSetAPI::findByHandle($handle);
+
+        if (is_null($handle)) {
+            return null;
+        }
+
+        return $handle->inCurrentSite();
     }
 }


### PR DESCRIPTION
Had a strange error when deploying my code to one of the servers, turns out that `GlobalSetAPI::findByHandle($handle)` returned `null` in some scenarios. Since this breaks the chain I made some minor adjustments to handle null responses.